### PR TITLE
feat(update.jenkins.io): terraform generation of the infra around update.jenkins.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ backend-config
 kubeconfig*
 terraform-plan-for-humans.txt
 terraform-plan-output.txt
+tfplan

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/oracle/oci" {
   version = "4.81.0"
   hashes = [
+    "h1:/SkpA6Z9iA9TVs856VDyY5oyXumBAlEypHXt0R1X0Jw=",
     "h1:L0417kja1pN8qw97zdd/T2IWG9/9pxf7IcN7y+t6fpg=",
     "zh:2ff8fc33bd80de53afd901bf691d8197a8ed5588255e9af27d0d897d81d2f476",
     "zh:30dc0dc313ae672424caa316e53e727bd825ee5c7fb5cdfde12c6489452e9c54",

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -6,20 +6,24 @@ parallel(
     // as per https://github.com/jenkins-infra/shared-tools/tree/main/terraform#jenkins-pipeline
     terraform(
       stagingCredentials: [
-        string(variable: 'ORACLE_OCI_CLI_USER', credentialsId: 'staging_oracle_oci_cli_user'),
-        string(variable: 'ORACLE_OCI_CLI_FINGERPRINT', credentialsId:'staging_oracle_oci_cli_fingerprint'),
+        string(variable: 'TF_VAR_region', credentialsId: 'oracle_oci_cli_region'),
+        string(variable: 'TF_VAR_tenancy_ocid', credentialsId: 'oracle_oci_cli_tenancy'),
+        string(variable: 'TF_VAR_user_ocid', credentialsId: 'staging_oracle_oci_cli_user'),
+        string(variable: 'TF_VAR_fingerprint', credentialsId:'staging_oracle_oci_cli_fingerprint'),
         sshUserPrivateKey(
           credentialsId: 'staging_oracle_oci_cli_key_content',
-          keyFileVariable: 'ORACLE_OCI_CLI_KEYFILE'
+          keyFileVariable: 'TF_VAR_private_key_path'
         ),
         file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging_terraform_oracle_backend_config'),
       ],
       productionCredentials: [
-        string(variable: 'ORACLE_OCI_CLI_USER', credentialsId: 'production_oracle_oci_cli_user'),
-        string(variable: 'ORACLE_OCI_CLI_FINGERPRINT', credentialsId:'production_oracle_oci_cli_fingerprint'),
+        string(variable: 'TF_VAR_region', credentialsId: 'oracle_oci_cli_region'),
+        string(variable: 'TF_VAR_tenancy_ocid', credentialsId: 'oracle_oci_cli_tenancy'),
+        string(variable: 'TF_VAR_user_ocid', credentialsId: 'production_oracle_oci_cli_user'),
+        string(variable: 'TF_VAR_fingerprint', credentialsId:'production_oracle_oci_cli_fingerprint'),
         sshUserPrivateKey(
           credentialsId: 'production_oracle_oci_cli_key_content',
-          keyFileVariable: 'ORACLE_OCI_CLI_KEYFILE'
+          keyFileVariable: 'TF_VAR_private_key_path'
         ),
         file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production_terraform_oracle_backend_config'),
       ],

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -10,6 +10,7 @@ parallel(
         string(variable: 'TF_VAR_tenancy_ocid', credentialsId: 'oracle_oci_cli_tenancy'),
         string(variable: 'TF_VAR_user_ocid', credentialsId: 'staging_oracle_oci_cli_user'),
         string(variable: 'TF_VAR_fingerprint', credentialsId:'staging_oracle_oci_cli_fingerprint'),
+        string(variable: 'TF_VAR_compartment_ocid', credentialsId: 'staging_oracle_oci_compartment_id'),
         sshUserPrivateKey(
           credentialsId: 'staging_oracle_oci_cli_key_content',
           keyFileVariable: 'TF_VAR_private_key_path'
@@ -21,6 +22,7 @@ parallel(
         string(variable: 'TF_VAR_tenancy_ocid', credentialsId: 'oracle_oci_cli_tenancy'),
         string(variable: 'TF_VAR_user_ocid', credentialsId: 'production_oracle_oci_cli_user'),
         string(variable: 'TF_VAR_fingerprint', credentialsId:'production_oracle_oci_cli_fingerprint'),
+        string(variable: 'TF_VAR_compartment_ocid', credentialsId: 'production_oracle_oci_compartment_id'),
         sshUserPrivateKey(
           credentialsId: 'production_oracle_oci_cli_key_content',
           keyFileVariable: 'TF_VAR_private_key_path'

--- a/datasources.tf
+++ b/datasources.tf
@@ -1,0 +1,17 @@
+# All resources of this project are contained within a "compartment", child of the tenant
+# The compartment ID is provided through variables, but we also need to retrive the name in 'current_compartment_name
+data "oci_identity_compartments" "all" {
+  compartment_id = var.tenancy_ocid
+  access_level   = "ACCESSIBLE"
+  state          = "ACTIVE"
+}
+locals {
+  current_compartment_name = element([for c in data.oci_identity_compartments.all.compartments : c.name if c.id == var.compartment_ocid], 0)
+}
+
+# Availability zone allows highly available system to be split in different "zones"
+# At least 1 is required, hence the datasource to refer it
+data "oci_identity_availability_domain" "availability_domain" {
+  compartment_id = var.compartment_ocid
+  ad_number      = 1
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  all_tags = {
+    scope = "terraform-managed"
+  }
+}

--- a/networks.tf
+++ b/networks.tf
@@ -1,0 +1,26 @@
+# Creating a network implies creating implicit resources
+# https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraformbestpractices_topic-vcndefaults.htm#managing_default_vcn_resources
+resource "oci_core_vcn" "default" {
+  compartment_id = var.compartment_ocid
+  display_name   = "default network for compartment ${local.current_compartment_name}"
+  cidr_blocks    = ["10.0.0.0/16"]
+  freeform_tags  = local.all_tags
+}
+
+# Sub network use to communicate with the outside world
+resource "oci_core_subnet" "public_subnet" {
+  cidr_block                 = "10.0.0.0/24"
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_vcn.default.id
+  freeform_tags              = local.all_tags
+  prohibit_public_ip_on_vnic = false
+}
+
+# Sub network use to communicate machine to machine internally
+resource "oci_core_subnet" "internal_subnet" {
+  cidr_block                 = "10.0.10.0/24"
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_vcn.default.id
+  freeform_tags              = local.all_tags
+  prohibit_public_ip_on_vnic = true
+}

--- a/networks.tf
+++ b/networks.tf
@@ -14,6 +14,7 @@ resource "oci_core_subnet" "public_subnet" {
   vcn_id                     = oci_core_vcn.default.id
   freeform_tags              = local.all_tags
   prohibit_public_ip_on_vnic = false
+
 }
 
 # Sub network use to communicate machine to machine internally
@@ -23,4 +24,43 @@ resource "oci_core_subnet" "internal_subnet" {
   vcn_id                     = oci_core_vcn.default.id
   freeform_tags              = local.all_tags
   prohibit_public_ip_on_vnic = true
+}
+
+data "oci_core_private_ips" "get_privates_ip_id" {
+  ip_address = oci_core_instance.updates_jenkins_io.private_ip
+  subnet_id  = oci_core_subnet.public_subnet.id
+}
+
+resource "oci_core_public_ip" "VMupdate_ip" {
+  compartment_id = var.compartment_ocid
+  lifetime       = "RESERVED"
+  display_name   = "Update VM public ip"
+  freeform_tags  = local.all_tags
+  private_ip_id  = data.oci_core_private_ips.get_privates_ip_id.private_ips[0].id
+}
+
+resource "oci_core_network_security_group" "VM_network_security_group" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.default.id
+  display_name   = "Update VM security group"
+  freeform_tags  = local.all_tags
+}
+
+resource "oci_core_network_security_group_security_rule" "ssh" {
+  network_security_group_id = oci_core_network_security_group.VM_network_security_group.id
+
+  description = "SSH"
+  direction   = "INGRESS"
+  protocol    = 6 #TCP
+  source_type = "CIDR_BLOCK"
+  source      = "82.64.5.129/32"
+  tcp_options {
+    destination_port_range {
+      min = 22
+      max = 22
+    }
+  }
+}
+output "instance_public_ip" {
+  value = oci_core_instance.updates_jenkins_io.public_ip
 }

--- a/networks.tf
+++ b/networks.tf
@@ -61,6 +61,30 @@ resource "oci_core_network_security_group_security_rule" "ssh" {
     }
   }
 }
+
+resource "oci_core_internet_gateway" "network_gateway" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.default.id
+  enabled        = true
+  display_name   = "Public network gateway"
+  freeform_tags  = local.all_tags
+}
+
+
+resource "oci_core_default_route_table" "network_route_table" {
+  manage_default_resource_id = oci_core_subnet.public_subnet.route_table_id
+
+  compartment_id = var.compartment_ocid
+
+  display_name   = "Public network route table"
+  freeform_tags  = local.all_tags
+  route_rules {
+    network_entity_id = oci_core_internet_gateway.network_gateway.id
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+  }
+}
+
 output "instance_public_ip" {
   value = oci_core_instance.updates_jenkins_io.public_ip
 }

--- a/networks.tf
+++ b/networks.tf
@@ -18,32 +18,12 @@ resource "oci_core_subnet" "public_subnet" {
 }
 
 # Sub network use to communicate machine to machine internally
-resource "oci_core_subnet" "internal_subnet" {
+resource "oci_core_subnet" "private_subnet" {
   cidr_block                 = "10.0.10.0/24"
   compartment_id             = var.compartment_ocid
   vcn_id                     = oci_core_vcn.default.id
   freeform_tags              = local.all_tags
   prohibit_public_ip_on_vnic = true
-}
-
-data "oci_core_private_ips" "updates_jenkins_io" {
-  ip_address = oci_core_instance.updates_jenkins_io.private_ip
-  subnet_id  = oci_core_subnet.public_subnet.id
-}
-
-resource "oci_core_public_ip" "updates_jenkins_io" {
-  compartment_id = var.compartment_ocid
-  lifetime       = "RESERVED"
-  display_name   = "updates.jenkins.io public ip"
-  freeform_tags  = local.all_tags
-  private_ip_id  = data.oci_core_private_ips.updates_jenkins_io.private_ips[0].id
-}
-
-resource "oci_core_network_security_group" "updates_jenkins_io" {
-  compartment_id = var.compartment_ocid
-  vcn_id         = oci_core_vcn.default.id
-  display_name   = "updates.jenkins.io security group"
-  freeform_tags  = local.all_tags
 }
 
 resource "oci_core_network_security_group_security_rule" "ssh_smerle" {
@@ -99,8 +79,4 @@ resource "oci_core_default_route_table" "network_route_table" {
     destination       = "0.0.0.0/0"
     destination_type  = "CIDR_BLOCK"
   }
-}
-
-output "instance_public_ip" {
-  value = oci_core_public_ip.updates_jenkins_io.ip_address
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,7 @@
 provider "oci" {
-  region = var.region
+  region           = var.region
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  private_key_path = var.private_key_path
+  fingerprint      = var.fingerprint
 }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -1,7 +1,7 @@
 data "oci_core_images" "updates_jenkins_io" {
   compartment_id           = var.compartment_ocid
   operating_system         = "Canonical Ubuntu"
-  operating_system_version = "22.04"
+  operating_system_version = "20.04"
   state                    = "AVAILABLE"
   shape                    = local.updates_jenkins_io_shape
   sort_by                  = "TIMECREATED"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -1,0 +1,71 @@
+data "oci_core_images" "updates_jenkins_io" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = "Canonical Ubuntu"
+  operating_system_version = "22.04"
+  state                    = "AVAILABLE"
+  shape                    = local.updates_jenkins_io_shape
+  sort_by                  = "TIMECREATED"
+  sort_order               = "DESC"
+}
+
+locals {
+  updates_jenkins_io_shape = "VM.Standard.A1.Flex" #imply ARM
+}
+
+resource "oci_core_volume_backup_policy" "updates_jenkins_io" {
+  compartment_id = var.compartment_ocid
+  schedules {
+    backup_type       = "FULL"
+    period            = "ONE_WEEK"
+    retention_seconds = "1296000" # 15 * 24 * 60 * 60 = 15 days
+  }
+  schedules {
+    backup_type       = "INCREMENTAL"
+    period            = "ONE_DAY"
+    retention_seconds = "604800" # 7 * 24 * 60 * 60 = 7 days
+  }
+  freeform_tags = local.all_tags
+}
+
+resource "oci_core_volume" "updates_jenkins_io" {
+  compartment_id      = var.compartment_ocid
+  availability_domain = data.oci_identity_availability_domain.availability_domain.name
+  display_name        = "Data volume for updates.jenkins.io"
+  size_in_gbs         = 1200
+  freeform_tags       = local.all_tags
+}
+
+resource "oci_core_volume_backup_policy_assignment" "volume_backup_policy_assignment" {
+  asset_id  = oci_core_volume.updates_jenkins_io.id
+  policy_id = oci_core_volume_backup_policy.updates_jenkins_io.id
+}
+
+resource "oci_core_instance" "updates_jenkins_io" {
+  availability_domain = data.oci_identity_availability_domain.availability_domain.name
+  compartment_id      = var.compartment_ocid
+  shape               = local.updates_jenkins_io_shape
+  shape_config {
+    ocpus         = 4
+    memory_in_gbs = 16
+  }
+  source_details {
+    source_type = "image"
+    source_id   = data.oci_core_images.updates_jenkins_io.images[0].id
+  }
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.public_subnet.id
+    assign_public_ip = true
+  }
+  metadata = {
+    ssh_authorized_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFrPRIlP8qplANgNa3IO5c1gh0ZqNNj17RZeYcm+Jcb jenkins-infra-team@googlegroups.com"
+  }
+  display_name  = "VM for updates.jenkins.io service"
+  freeform_tags = local.all_tags
+}
+
+resource "oci_core_volume_attachment" "updates_jenkins_io_data" {
+  # Paravirtualized attachment is expected to automount the data volume (compared to "iscsi")
+  attachment_type = "paravirtualized"
+  instance_id     = oci_core_instance.updates_jenkins_io.id
+  volume_id       = oci_core_volume.updates_jenkins_io.id
+}

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -64,6 +64,17 @@ resource "oci_core_instance" "updates_jenkins_io" {
   freeform_tags = local.all_tags
 }
 
+resource "oci_core_vnic_attachment" "secondary_vnic_attachment" {
+  create_vnic_details {
+    display_name  = "internal_vnic for updates.jenkins.io"
+    freeform_tags = local.all_tags
+    nsg_ids       = [oci_core_network_security_group.updates_jenkins_io.id]
+    subnet_id     = oci_core_subnet.internal_subnet.id
+  }
+  instance_id  = oci_core_instance.updates_jenkins_io.id
+  display_name = "internal_vnic attachment for updates.jenkins.io"
+}
+
 resource "oci_core_volume_attachment" "updates_jenkins_io_data" {
   # Paravirtualized attachment is expected to automount the data volume (compared to "iscsi")
   attachment_type = "paravirtualized"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -54,7 +54,8 @@ resource "oci_core_instance" "updates_jenkins_io" {
   }
   create_vnic_details {
     subnet_id        = oci_core_subnet.public_subnet.id
-    assign_public_ip = true
+    assign_public_ip = false #will assign a non ephemeral one (RESERVED ip)
+    nsg_ids          = [oci_core_network_security_group.VM_network_security_group.id]
   }
   metadata = {
     ssh_authorized_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFrPRIlP8qplANgNa3IO5c1gh0ZqNNj17RZeYcm+Jcb jenkins-infra-team@googlegroups.com"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -1,7 +1,7 @@
 data "oci_core_images" "updates_jenkins_io" {
   compartment_id           = var.compartment_ocid
   operating_system         = "Canonical Ubuntu"
-  operating_system_version = "20.04"
+  operating_system_version = "22.04"
   state                    = "AVAILABLE"
   shape                    = local.updates_jenkins_io_shape
   sort_by                  = "TIMECREATED"
@@ -55,7 +55,7 @@ resource "oci_core_instance" "updates_jenkins_io" {
   create_vnic_details {
     subnet_id        = oci_core_subnet.public_subnet.id
     assign_public_ip = false #will assign a non ephemeral one (RESERVED ip)
-    nsg_ids          = [oci_core_network_security_group.VM_network_security_group.id]
+    nsg_ids          = [oci_core_network_security_group.updates_jenkins_io.id]
   }
   metadata = {
     ssh_authorized_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFrPRIlP8qplANgNa3IO5c1gh0ZqNNj17RZeYcm+Jcb jenkins-infra-team@googlegroups.com"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -28,11 +28,12 @@ resource "oci_core_volume_backup_policy" "updates_jenkins_io" {
 }
 
 resource "oci_core_volume" "updates_jenkins_io" {
-  compartment_id      = var.compartment_ocid
-  availability_domain = data.oci_identity_availability_domain.availability_domain.name
-  display_name        = "Data volume for updates.jenkins.io"
-  size_in_gbs         = 1200
-  freeform_tags       = local.all_tags
+  compartment_id       = var.compartment_ocid
+  availability_domain  = data.oci_identity_availability_domain.availability_domain.name
+  display_name         = "Data volume for updates.jenkins.io"
+  size_in_gbs          = 1200
+  freeform_tags        = local.all_tags
+  is_auto_tune_enabled = true
 }
 
 resource "oci_core_volume_backup_policy_assignment" "volume_backup_policy_assignment" {
@@ -80,4 +81,6 @@ resource "oci_core_volume_attachment" "updates_jenkins_io_data" {
   attachment_type = "paravirtualized"
   instance_id     = oci_core_instance.updates_jenkins_io.id
   volume_id       = oci_core_volume.updates_jenkins_io.id
+  display_name    = "volume attachment for updates.jenkins.io"
+  device          = "/dev/oracleoci/oraclevdb"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,35 @@
+# warning the image ocid is depending on the region !
 variable "region" {
   type        = string
-  default     = "us-phoenix-1"
   description = "An OCI region"
+}
+
+variable "tenancy_ocid" {
+  type        = string
+  description = "The tenancy (root compartment) OCID"
+  sensitive   = true
+}
+
+variable "compartment_ocid" {
+  type        = string
+  description = "The compartment OCID where to use for resources"
+  sensitive   = true
+}
+
+variable "user_ocid" {
+  type        = string
+  description = "An OCI user OCID"
+  sensitive   = true
+}
+
+variable "private_key_path" {
+  type        = string
+  description = "An OCI private key path"
+  sensitive   = true
+}
+
+variable "fingerprint" {
+  type        = string
+  description = "An OCI fingerprint"
+  sensitive   = true
 }


### PR DESCRIPTION
In order to migrate update.jenkins.io (as per https://github.com/jenkins-infra/helpdesk/issues/2649), we need to provide as code the infrastructure to host it :
 - lan (public and internal subnets)
 - public ip
 - ubuntu 22.04 VM (4 vcpu, 16Gb)
 - datastore 1200Gb
 - firewall rules