### PR TITLE
Fix(update.jenkins.io) add hostname and templatize puppet

### DIFF
--- a/cloudinit-updates-jenkins-io.tftpl
+++ b/cloudinit-updates-jenkins-io.tftpl
@@ -17,6 +17,8 @@ runcmd:
   - [ dpkg, -i, /run/puppetinstall/puppet6-release-focal.deb ]
   - [ apt-get, update, -y ]
   - [ apt-get, install, "puppet-agent=6.23.0*", --yes, --quiet, --no-install-recommends ]
+  # Pin package version to avoid agent newer than the puppetmaster
+  - [ apt-mark, hold, puppet-agent]
   # see above comment in the "write_files" section
   - [ mv, /run/puppetinstall/puppet.conf, /etc/puppetlabs/puppet/puppet.conf]
   - [ systemctl, enable, puppet ]

--- a/cloudinit-updates-jenkins-io.tftpl
+++ b/cloudinit-updates-jenkins-io.tftpl
@@ -1,0 +1,19 @@
+#cloud-config
+write_files:
+  - path: /run/puppetinstall/puppet.conf
+    owner: root:root
+    permissions: '0755'
+    content: |
+      [main]
+      server = puppet.jenkins.io
+      [agent]
+      certname = ${hostname}
+runcmd:
+  - [ mkdir, -p, /run/puppetinstall ]
+  - [ wget, "https://apt.puppetlabs.com/puppet6-release-focal.deb", -O, /run/puppetinstall/puppet6-release-focal.deb ]
+  - [ dpkg, -i, /run/puppetinstall/puppet6-release-focal.deb ]
+  - [ apt-get, update, -y ]
+  - [ apt-get, install, "puppet-agent=6.23.0*", --yes, --quiet, --no-install-recommends ]
+  - [ mv, /run/puppetinstall/puppet.conf, /etc/puppetlabs/puppet/puppet.conf]
+  - [ systemctl, start, puppet ]
+  - [ systemctl, enable, puppet ]

--- a/cloudinit-updates-jenkins-io.tftpl
+++ b/cloudinit-updates-jenkins-io.tftpl
@@ -1,8 +1,10 @@
 #cloud-config
 write_files:
+  #config file for puppet agent on this VM (updates.jenkins.io)
+  #not directly at the destination path as it will fail the packet installation
   - path: /run/puppetinstall/puppet.conf
     owner: root:root
-    permissions: '0755'
+    permissions: '0640'
     content: |
       [main]
       server = puppet.jenkins.io
@@ -14,6 +16,7 @@ runcmd:
   - [ dpkg, -i, /run/puppetinstall/puppet6-release-focal.deb ]
   - [ apt-get, update, -y ]
   - [ apt-get, install, "puppet-agent=6.23.0*", --yes, --quiet, --no-install-recommends ]
+  # move the temporaty puppetagent config file in the correct place /run/puppetinstall/puppet.conf
   - [ mv, /run/puppetinstall/puppet.conf, /etc/puppetlabs/puppet/puppet.conf]
   - [ systemctl, start, puppet ]
   - [ systemctl, enable, puppet ]

--- a/cloudinit-updates-jenkins-io.tftpl
+++ b/cloudinit-updates-jenkins-io.tftpl
@@ -17,7 +17,7 @@ runcmd:
   - [ dpkg, -i, /run/puppetinstall/puppet6-release-focal.deb ]
   - [ apt-get, update, -y ]
   - [ apt-get, install, "puppet-agent=6.23.0*", --yes, --quiet, --no-install-recommends ]
-  # see above comment in the write_files section
+  # see above comment in the "write_files" section
   - [ mv, /run/puppetinstall/puppet.conf, /etc/puppetlabs/puppet/puppet.conf]
   - [ systemctl, enable, puppet ]
   - [ systemctl, start, puppet ]

--- a/cloudinit-updates-jenkins-io.tftpl
+++ b/cloudinit-updates-jenkins-io.tftpl
@@ -2,6 +2,8 @@
 write_files:
   #config file for puppet agent on this VM (updates.jenkins.io)
   #not directly at the destination path as it will fail the packet installation
+  #when writing files, do not use /tmp dir as it races with systemd-tmpfiles-clean LP: #1707222. Use /run/somedir instead. : https://cloudinit.readthedocs.io/en/latest/topics/modules.html#runcmd
+
   - path: /run/puppetinstall/puppet.conf
     owner: root:root
     permissions: '0640'
@@ -16,7 +18,7 @@ runcmd:
   - [ dpkg, -i, /run/puppetinstall/puppet6-release-focal.deb ]
   - [ apt-get, update, -y ]
   - [ apt-get, install, "puppet-agent=6.23.0*", --yes, --quiet, --no-install-recommends ]
-  # move the temporaty puppetagent config file in the correct place /run/puppetinstall/puppet.conf
+  # see above comment in the write_files section
   - [ mv, /run/puppetinstall/puppet.conf, /etc/puppetlabs/puppet/puppet.conf]
-  - [ systemctl, start, puppet ]
   - [ systemctl, enable, puppet ]
+  - [ systemctl, start, puppet ]

--- a/cloudinit-updates-jenkins-io.tftpl
+++ b/cloudinit-updates-jenkins-io.tftpl
@@ -1,9 +1,8 @@
 #cloud-config
 write_files:
-  #config file for puppet agent on this VM (updates.jenkins.io)
-  #not directly at the destination path as it will fail the packet installation
-  #when writing files, do not use /tmp dir as it races with systemd-tmpfiles-clean LP: #1707222. Use /run/somedir instead. : https://cloudinit.readthedocs.io/en/latest/topics/modules.html#runcmd
-
+  # Configuration file for puppet agent on this VM (${hostname})
+  # Not directly at the destination path as it would get the the puppet package installation stuck (asking to override)
+  # Also, when writing files, do not use /tmp dir as it races with systemd-tmp. Use /run/<somedir> instead (as per. : https://cloudinit.readthedocs.io/en/latest/topics/modules.html#runcmd)
   - path: /run/puppetinstall/puppet.conf
     owner: root:root
     permissions: '0640'

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -55,10 +55,11 @@ resource "oci_core_instance" "updates_jenkins_io" {
     source_id   = data.oci_core_images.updates_jenkins_io.images[0].id
   }
   create_vnic_details {
-    subnet_id        = oci_core_subnet.public_subnet.id
-    assign_public_ip = false #will assign a non ephemeral one (RESERVED ip)
-    nsg_ids          = [oci_core_network_security_group.updates_jenkins_io.id]
-    hostname_label   = local.updates_jenkins_io_hostname
+    subnet_id                 = oci_core_subnet.public_subnet.id
+    assign_public_ip          = false #will assign a non ephemeral one (RESERVED ip)
+    nsg_ids                   = [oci_core_network_security_group.updates_jenkins_io.id]
+    hostname_label            = local.updates_jenkins_io_hostname
+    assign_private_dns_record = true
   }
   metadata = {
     ssh_authorized_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFrPRIlP8qplANgNa3IO5c1gh0ZqNNj17RZeYcm+Jcb jenkins-infra-team@googlegroups.com"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -1,7 +1,7 @@
 data "oci_core_images" "updates_jenkins_io" {
   compartment_id           = var.compartment_ocid
   operating_system         = "Canonical Ubuntu"
-  operating_system_version = "22.04"
+  operating_system_version = "20.04"
   state                    = "AVAILABLE"
   shape                    = local.updates_jenkins_io_shape
   sort_by                  = "TIMECREATED"
@@ -9,7 +9,8 @@ data "oci_core_images" "updates_jenkins_io" {
 }
 
 locals {
-  updates_jenkins_io_shape = "VM.Standard.A1.Flex" #imply ARM
+  updates_jenkins_io_shape    = "VM.Standard.A1.Flex" #imply ARM
+  updates_jenkins_io_hostname = "oracle.updates.jenkins.io"
 }
 
 resource "oci_core_volume_backup_policy" "updates_jenkins_io" {
@@ -57,9 +58,11 @@ resource "oci_core_instance" "updates_jenkins_io" {
     subnet_id        = oci_core_subnet.public_subnet.id
     assign_public_ip = false #will assign a non ephemeral one (RESERVED ip)
     nsg_ids          = [oci_core_network_security_group.updates_jenkins_io.id]
+    hostname_label   = local.updates_jenkins_io_hostname
   }
   metadata = {
     ssh_authorized_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFrPRIlP8qplANgNa3IO5c1gh0ZqNNj17RZeYcm+Jcb jenkins-infra-team@googlegroups.com"
+    user_data           = base64encode(templatefile("./cloudinit-updates-jenkins-io.tftpl", { hostname = "${local.updates_jenkins_io_hostname}" }))
   }
   display_name  = "Virtual Machine for updates.jenkins.io service"
   freeform_tags = local.all_tags

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -55,17 +55,15 @@ resource "oci_core_instance" "updates_jenkins_io" {
     source_id   = data.oci_core_images.updates_jenkins_io.images[0].id
   }
   create_vnic_details {
-    subnet_id                 = oci_core_subnet.public_subnet.id
-    assign_public_ip          = false #will assign a non ephemeral one (RESERVED ip)
-    nsg_ids                   = [oci_core_network_security_group.updates_jenkins_io.id]
-    hostname_label            = local.updates_jenkins_io_hostname
-    assign_private_dns_record = true
+    subnet_id        = oci_core_subnet.public_subnet.id
+    assign_public_ip = false #will assign a non ephemeral one (RESERVED ip)
+    nsg_ids          = [oci_core_network_security_group.updates_jenkins_io.id]
   }
   metadata = {
     ssh_authorized_keys = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFrPRIlP8qplANgNa3IO5c1gh0ZqNNj17RZeYcm+Jcb jenkins-infra-team@googlegroups.com"
     user_data           = base64encode(templatefile("./cloudinit-updates-jenkins-io.tftpl", { hostname = "${local.updates_jenkins_io_hostname}" }))
   }
-  display_name  = "Virtual Machine for updates.jenkins.io service"
+  display_name  = local.updates_jenkins_io_hostname
   freeform_tags = local.all_tags
 }
 


### PR DESCRIPTION
install puppet agent from cloudinit with correct hostname. [Had to downgrade from ubuntu 22.04 to 20.04 for compliance.](https://github.com/jenkins-infra/helpdesk/issues/2982#issuecomment-1177489635)